### PR TITLE
Adding CORS, Adding README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ Commands:
   help [command]            display help for command
 ```
 
+### Map Preview
+Map Previews by Mapbox GL JS, MapLibre GL JS, and ArcGIS API for Javascript can be seen from http://localhost:8080 (or any specified port).
+
+### ArcGIS REST API response
+Once "itoma serve" starts, we can see the ArcGIS REST API responses from http://localhost:8080/arcgis/rest/services/{any_name}/VectorTileServer.  
+
+* index.json: http://localhost:8080/arcgis/rest/services/{any_name}/VectorTileServer/index.json
+* root.json (style): http://localhost:8080/arcgis/rest/services/{any_name}/VectorTileServer/resources/styles/root.json
+* sprites: http://localhost:8080/arcgis/rest/services/{any_name}/VectorTileServer/resources/sprites/
+* glyphs (fonts): http://localhost:8080/arcgis/rest/services/{any_name}/VectorTileServer/resources/fonts/
+* tilemap: http://localhost:8080/arcgis/rest/services/{any_name}/VectorTileServer/tilemap
+    * Please be advised that the tilemap range (of ZL) is fixed. (You may need to edit source code to adjust it for your own tile range.) 
+
+It is important to understand that ArcGIS Online now supports https protocol only (not http). When you use unvt/itoma to preview your tile with ArcGIS online, please use https protocol for localhost.
+
+
 ## Development
 
 ```

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@unvt/charites": "^0.1.4",
     "commander": "^9.0.0",
+    "cors": "^2.8.5",
     "express": "^4.17.3",
     "express-http-proxy": "^1.6.3",
     "node-fetch": "^2.6.7"

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -8,6 +8,8 @@ import { parser } from '@unvt/charites/dist/lib/yaml-parser'
 import type { VectorSourceSpecification } from '@maplibre/maplibre-gl-style-spec/types'
 import { Server } from 'http'
 
+const cors = require('cors') // 21 April 2022
+
 export interface ServeOptions {
   mapboxAccessToken?: string
   arcgisAccessToken?: string
@@ -64,6 +66,7 @@ export async function serve(source: string, options: ServeOptions) {
   const glyphsUrl = style.glyphs ? new URL(style.glyphs) : undefined
 
   const app = express()
+  app.use(cors()) // 21 April 2022
   if (options.trustProxy) {
     app.set('trust proxy', true)
   }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -8,7 +8,7 @@ import { parser } from '@unvt/charites/dist/lib/yaml-parser'
 import type { VectorSourceSpecification } from '@maplibre/maplibre-gl-style-spec/types'
 import { Server } from 'http'
 
-const cors = require('cors') // 21 April 2022
+const cors = require('cors') 
 
 export interface ServeOptions {
   mapboxAccessToken?: string
@@ -66,7 +66,7 @@ export async function serve(source: string, options: ServeOptions) {
   const glyphsUrl = style.glyphs ? new URL(style.glyphs) : undefined
 
   const app = express()
-  app.use(cors()) // 21 April 2022
+  app.use(cors()) 
   if (options.trustProxy) {
     app.set('trust proxy', true)
   }


### PR DESCRIPTION
I have added CORS setting so that the service can be consumed in ArcGIS Online at the different origin. In addition, I added some explanation at README.